### PR TITLE
Reconnect redux

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -725,18 +725,20 @@ The 'ZMQ_RECONNECT_STOP_CONN_REFUSED' option will stop reconnection when 0MQ
 receives the ECONNREFUSED return code from the connect.  This indicates that
 there is no code bound to the specified endpoint.
 
-The 'ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED' option will stop reconnection when
+The 'ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED' option will stop reconnection if
 the 0MQ handshake fails.  This can be used to detect and/or prevent errant
-connection attempts to non-0MQ sockets.
+connection attempts to non-0MQ sockets.  Note that when specifying this option
+you may also want to set `ZMQ_HANDSHAKE_IVL` -- the default handshake interval
+is 30000 (30 seconds), which is typically too large.
 
 NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int
 Option value unit:: 0, ZMQ_RECONNECT_STOP_CONN_REFUSED, ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED, ZMQ_RECONNECT_STOP_CONN_REFUSED | ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED
-
 Default value:: 0
-Applicable socket types:: all, only for connection-oriented transports
+Applicable socket types:: all, only for connection-oriented transports (ZMQ_HANDSHAKE_IVL is
+not applicable for ZMQ_STREAM sockets)
 
 
 ZMQ_RECOVERY_IVL: Set multicast recovery interval

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -489,6 +489,20 @@ Default value:: not set
 Applicable socket types:: all
 
 
+ZMQ_MIN_ZMTP_VERSION: Minimum acceptable ZMTP version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the minimum ZMTP version that this socket supports.  If a
+peer socket identifies as an earlier version during handshaking,
+the connection will be immedidately closed.
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: char[2]
+Option value unit:: 0, MIN_ZMTP_VERSION_1_0, MIN_ZMTP_VERSION_2_0, MIN_ZMTP_VERSION_3_0, MIN_ZMTP_VERSION_3_1
+Default value:: not set
+Applicable socket types:: all but ZMQ_STREAM
+
 ZMQ_MULTICAST_HOPS: Maximum network hops for multicast packets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Sets the time-to-live field in every multicast packet sent from this socket.
@@ -711,9 +725,16 @@ The 'ZMQ_RECONNECT_STOP_CONN_REFUSED' option will stop reconnection when 0MQ
 receives the ECONNREFUSED return code from the connect.  This indicates that
 there is no code bound to the specified endpoint.
 
+The 'ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED' option will stop reconnection when
+the 0MQ handshake fails.  This can be used to detect and/or prevent errant
+connection attempts to non-0MQ sockets.
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
-Option value unit:: ZMQ_RECONNECT_STOP_CONN_REFUSED
+Option value unit:: 0, ZMQ_RECONNECT_STOP_CONN_REFUSED, ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED, ZMQ_RECONNECT_STOP_CONN_REFUSED | ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED
+
 Default value:: 0
 Applicable socket types:: all, only for connection-oriented transports
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -678,10 +678,17 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_WSS_TRUST_SYSTEM 107
 #define ZMQ_ONLY_FIRST_SUBSCRIBE 108
 #define ZMQ_RECONNECT_STOP 109
-#define ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED 110
+#define ZMQ_MIN_ZMTP_VERSION 110
 
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1
+#define ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED 0x2
+
+/* ZMQ_MIN_ZMTP_VERSION options                                               */
+static const char MIN_ZMTP_VERSION_1_0[] = {1, 0};
+static const char MIN_ZMTP_VERSION_2_0[] = {2, 0};
+static const char MIN_ZMTP_VERSION_3_0[] = {3, 0};
+static const char MIN_ZMTP_VERSION_3_1[] = {3, 1};
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_ZERO_COPY_RECV 10

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -254,6 +254,7 @@ zmq::options_t::options_t () :
     memset (curve_public_key, 0, CURVE_KEYSIZE);
     memset (curve_secret_key, 0, CURVE_KEYSIZE);
     memset (curve_server_key, 0, CURVE_KEYSIZE);
+    memset (min_zmtp, 0, 2);
 #if defined ZMQ_HAVE_VMCI
     vmci_buffer_size = 0;
     vmci_buffer_min_size = 0;
@@ -779,6 +780,13 @@ int zmq::options_t::setsockopt (int option_,
                                                       &multicast_loop);
 
 #ifdef ZMQ_BUILD_DRAFT_API
+
+        case ZMQ_MIN_ZMTP_VERSION:
+            if (optvallen_ == 2) {
+                memcpy (min_zmtp, optval_, 2);
+                return 0;
+            }
+
         case ZMQ_IN_BATCH_SIZE:
             if (is_int && value > 0) {
                 in_batch_size = value;
@@ -1219,12 +1227,21 @@ int zmq::options_t::getsockopt (int option_,
             break;
 
 #ifdef ZMQ_BUILD_DRAFT_API
+
+        case ZMQ_MIN_ZMTP_VERSION:
+            if (*optvallen_ == 2) {
+                memcpy (optval_, min_zmtp, 2);
+                return 0;
+            }
+            break;
+
         case ZMQ_ROUTER_NOTIFY:
             if (is_int) {
                 *value = router_notify;
                 return 0;
             }
             break;
+
         case ZMQ_IN_BATCH_SIZE:
             if (is_int) {
                 *value = in_batch_size;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -291,6 +291,9 @@ struct options_t
     // Version of monitor events to emit
     int monitor_event_version;
 
+    // minimum supported version of ZMTP
+    char min_zmtp[2];
+
     //  WSS Keys
     std::string wss_key_pem;
     std::string wss_cert_pem;

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -451,7 +451,7 @@ void zmq::session_base_t::engine_error (zmq::i_engine::error_reason_t reason_)
                 reconnect ();
                 break;
             }
-            /* FALLTHROUGH */
+
         case i_engine::protocol_error:
             if (_pending) {
                 if (_pipe)

--- a/src/stream_engine_base.cpp
+++ b/src/stream_engine_base.cpp
@@ -122,7 +122,6 @@ zmq::stream_engine_base_t::stream_engine_base_t (
     _has_timeout_timer (false),
     _has_heartbeat_timer (false),
     _peer_address (get_peer_address (fd_)),
-    _greeting_bytes_read (0),
     _s (fd_),
     _handle (static_cast<handle_t> (NULL)),
     _plugged (false),

--- a/src/stream_engine_base.cpp
+++ b/src/stream_engine_base.cpp
@@ -734,10 +734,7 @@ void zmq::stream_engine_base_t::timer_event (int id_)
     if (id_ == handshake_timer_id) {
         _has_handshake_timer = false;
         //  handshake timer expired before handshake completed, so engine fail
-        if (_greeting_bytes_read > 0)
-            error (protocol_error);
-        else
-            error (timeout_error);
+        error (timeout_error);
     } else if (id_ == heartbeat_ivl_timer_id) {
         _next_msg = &stream_engine_base_t::produce_ping_message;
         out_event ();

--- a/src/stream_engine_base.hpp
+++ b/src/stream_engine_base.hpp
@@ -160,6 +160,9 @@ class stream_engine_base_t : public io_object_t, public i_engine
 
     const std::string _peer_address;
 
+    //  Size of greeting received so far
+    unsigned int _greeting_bytes_read;
+
   private:
     bool in_event_internal ();
 

--- a/src/stream_engine_base.hpp
+++ b/src/stream_engine_base.hpp
@@ -160,9 +160,6 @@ class stream_engine_base_t : public io_object_t, public i_engine
 
     const std::string _peer_address;
 
-    //  Size of greeting received so far
-    unsigned int _greeting_bytes_read;
-
   private:
     bool in_event_internal ();
 

--- a/src/zmtp_engine.cpp
+++ b/src/zmtp_engine.cpp
@@ -69,6 +69,7 @@ zmq::zmtp_engine_t::zmtp_engine_t (
   const endpoint_uri_pair_t &endpoint_uri_pair_) :
     stream_engine_base_t (fd_, options_, endpoint_uri_pair_),
     _greeting_size (v2_greeting_size),
+    _greeting_bytes_read (0),
     _subscription_required (false),
     _heartbeat_timeout (0)
 {

--- a/src/zmtp_engine.cpp
+++ b/src/zmtp_engine.cpp
@@ -137,13 +137,6 @@ bool zmq::zmtp_engine_t::handshake ()
     if (_outsize == 0)
         set_pollout ();
 
-    #if 0
-    if (_has_handshake_timer) {
-        cancel_timer (handshake_timer_id);
-        _has_handshake_timer = false;
-    }
-    #endif
-
     return true;
 }
 
@@ -457,7 +450,6 @@ bool zmq::zmtp_engine_t::handshake_v3_1 ()
     _encoder = new (std::nothrow) v3_1_encoder_t (_options.out_batch_size);
     alloc_assert (_encoder);
 
-    // TODO check
     _decoder = new (std::nothrow) v2_decoder_t (
       _options.in_batch_size, _options.maxmsgsize, _options.zero_copy);
     alloc_assert (_decoder);

--- a/src/zmtp_engine.hpp
+++ b/src/zmtp_engine.hpp
@@ -119,9 +119,6 @@ class zmtp_engine_t ZMQ_FINAL : public stream_engine_base_t
     unsigned char _greeting_recv[v3_greeting_size];
     unsigned char _greeting_send[v3_greeting_size];
 
-    //  Size of greeting received so far
-    unsigned int _greeting_bytes_read;
-
     //  Indicates whether the engine is to inject a phantom
     //  subscription message into the incoming stream.
     //  Needed to support old peers.

--- a/src/zmtp_engine.hpp
+++ b/src/zmtp_engine.hpp
@@ -119,6 +119,9 @@ class zmtp_engine_t ZMQ_FINAL : public stream_engine_base_t
     unsigned char _greeting_recv[v3_greeting_size];
     unsigned char _greeting_send[v3_greeting_size];
 
+    //  Size of greeting received so far
+    unsigned int _greeting_bytes_read;
+
     //  Indicates whether the engine is to inject a phantom
     //  subscription message into the incoming stream.
     //  Needed to support old peers.

--- a/tests/test_stream_timeout.cpp
+++ b/tests/test_stream_timeout.cpp
@@ -48,7 +48,7 @@ static void test_stream_handshake_timeout_accept ()
       zmq_setsockopt (stream, ZMQ_LINGER, &zero, sizeof (zero)));
 
     //  We'll be using this socket to test TCP stream handshake timeout
-    void *dealer = test_context_socket (ZMQ_DEALER);
+    void *dealer = test_context_socket (ZMQ_SUB);
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_setsockopt (dealer, ZMQ_LINGER, &zero, sizeof (zero)));
     int val, tenth = 100;
@@ -110,7 +110,7 @@ static void test_stream_handshake_timeout_connect ()
     bind_loopback_ipv4 (stream, my_endpoint, sizeof my_endpoint);
 
     //  We'll be using this socket to test TCP stream handshake timeout
-    void *dealer = test_context_socket (ZMQ_DEALER);
+    void *dealer = test_context_socket (ZMQ_SUB);
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_setsockopt (dealer, ZMQ_LINGER, &zero, sizeof (zero)));
     int val, tenth = 100;
@@ -136,7 +136,7 @@ static void test_stream_handshake_timeout_connect ()
 
     TEST_ASSERT_SUCCESS_ERRNO (zmq_socket_monitor (
       dealer, "inproc://monitor-dealer",
-      ZMQ_EVENT_CONNECTED | ZMQ_EVENT_DISCONNECTED | ZMQ_EVENT_ACCEPTED));
+      ZMQ_EVENT_ALL));
 
     //  Connect to the inproc endpoint so we'll get events
     TEST_ASSERT_SUCCESS_ERRNO (
@@ -145,11 +145,18 @@ static void test_stream_handshake_timeout_connect ()
     // connect dealer socket to non-sending stream socket
     TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (dealer, my_endpoint));
 
-    // we should get ZMQ_EVENT_CONNECTED and then ZMQ_EVENT_DISCONNECTED
-    int event = get_monitor_event (dealer_mon, NULL, NULL);
-    TEST_ASSERT_EQUAL_INT (ZMQ_EVENT_CONNECTED, event);
-    event = get_monitor_event (dealer_mon, NULL, NULL);
-    TEST_ASSERT_EQUAL_INT (ZMQ_EVENT_DISCONNECTED, event);
+    int value;
+    char *event_address;
+    int event = get_monitor_event_with_timeout (dealer_mon, &value, &event_address,
+                                             2 * 1000);
+    int limit = 0;
+    while ((event != -1) && (++limit < 1000)) {
+        const char* eventName = get_zmqEventName(event);
+        printf("Got event: %s\n", eventName);
+        //print_unexpected_event_stderr (event, rc, 0, -1);
+        event = get_monitor_event_with_timeout (dealer_mon, &value, &event_address,
+                                             2 * 1000);
+    }
 
     test_context_socket_close (dealer);
     test_context_socket_close (dealer_mon);

--- a/tests/testutil_monitoring.cpp
+++ b/tests/testutil_monitoring.cpp
@@ -366,3 +366,20 @@ const char* get_zmqEventName(uint64_t event)
       default                                   : return "UNKNOWN";
    }
 }
+
+void print_events(void* socket, int timeout, int limit)
+{
+    // print events received
+    int value;
+    char *event_address;
+    int event = get_monitor_event_with_timeout (socket, &value, &event_address,
+                                             timeout);
+    int i = 0;;
+    while ((event != -1) && (++i < limit)) {
+        const char* eventName = get_zmqEventName(event);
+        printf("Got event: %s\n", eventName);
+        event = get_monitor_event_with_timeout (socket, &value, &event_address,
+                                             timeout);
+    }
+
+}

--- a/tests/testutil_monitoring.cpp
+++ b/tests/testutil_monitoring.cpp
@@ -343,3 +343,26 @@ void expect_monitor_event_v2 (void *monitor_,
     free (remote_address);
     TEST_ASSERT_FALSE_MESSAGE (failed, buf);
 }
+
+
+const char* get_zmqEventName(uint64_t event)
+{
+   switch(event) {
+      case ZMQ_EVENT_CONNECTED                  : return "CONNECTED";
+      case ZMQ_EVENT_CONNECT_DELAYED            : return "CONNECT_DELAYED";
+      case ZMQ_EVENT_CONNECT_RETRIED            : return "CONNECT_RETRIED";
+      case ZMQ_EVENT_LISTENING                  : return "LISTENING";
+      case ZMQ_EVENT_BIND_FAILED                : return "BIND_FAILED";
+      case ZMQ_EVENT_ACCEPTED                   : return "ACCEPTED";
+      case ZMQ_EVENT_ACCEPT_FAILED              : return "ACCEPT_FAILED";
+      case ZMQ_EVENT_CLOSED                     : return "CLOSED";
+      case ZMQ_EVENT_CLOSE_FAILED               : return "CLOSE_FAILED";
+      case ZMQ_EVENT_DISCONNECTED               : return "DISCONNECTED";
+      case ZMQ_EVENT_MONITOR_STOPPED            : return "MONITOR_STOPPED";
+      case ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL : return "HANDSHAKE_FAILED_NO_DETAIL";
+      case ZMQ_EVENT_HANDSHAKE_SUCCEEDED        : return "HANDSHAKE_SUCCEEDED";
+      case ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL  : return "HANDSHAKE_FAILED_PROTOCOL";
+      case ZMQ_EVENT_HANDSHAKE_FAILED_AUTH      : return "HANDSHAKE_FAILED_AUTH";
+      default                                   : return "UNKNOWN";
+   }
+}

--- a/tests/testutil_monitoring.hpp
+++ b/tests/testutil_monitoring.hpp
@@ -78,5 +78,6 @@ void expect_monitor_event_v2 (void *monitor_,
 
 
 const char* get_zmqEventName(uint64_t event);
+void print_events(void* socket, int timeout, int limit);
 
 #endif

--- a/tests/testutil_monitoring.hpp
+++ b/tests/testutil_monitoring.hpp
@@ -76,4 +76,7 @@ void expect_monitor_event_v2 (void *monitor_,
                               const char *expected_local_address_ = NULL,
                               const char *expected_remote_address_ = NULL);
 
+
+const char* get_zmqEventName(uint64_t event);
+
 #endif


### PR DESCRIPTION
# Connect/reconnect with 0mq

The purpose of this PR is to close the loop on connect/reconnect options that began with <https://github.com/zeromq/libzmq/pull/3831>.

We want to take advantage of 0mq's support for automatic reconnection of sockets that become disconnected, but there are some edge cases that are problematic for us.

Because of the way [OZ](https://github.com/nyfix/OZ/) does [dynamic discovery](https://github.com/nyfix/OZ/blob/master/doc/Naming-Service.md), processes don't bind to known ports -- (almost) all ports are assigned dynamically.  These port assignments are then published to the one-and-only known port, which then forwards them to all the other processes.

With automatic reconnection enabled, if a process terminates and restarts (e.g., because of a crash), 0mq will continue to try to reconnect to its original port.  

The scenarios we care about are:

1. Process terminates, peer attempts to reconnect but gets ECONNREFUSED.  This is already handled by the earlier PR.
2. Process mistakenly attempts to connect to a port that is not a 0mq process:
    1.  The non-0mq process unilaterally closes the connection, presumably because the 0mq process did not adhere to the protocol expected by the non-0mq process.
    2.  The non-0mq process does nothing -- i.e., it does not respond to the 0mq greeting.
    3.  The non-0mq process does respond in some fashion, or at least sends data on the connection that `receive_greeting` can read.

## 1. No process listening at port

This is handled by the ZMQ_RECONNECT_STOP/ZMQ_RECONNECT_STOP_CONN_REFUSED sockopt.

```
#0  zmq::socket_base_t::event_closed (this=0x614590, endpoint_uri_pair_=..., fd_=16) at /home/btorpey/work/libzmq/master/src/src/socket_base.cpp:1866
#1  0x00007ffff7b8f3cc in zmq::stream_connecter_base_t::close (this=0x7fffe80008c0) at /home/btorpey/work/libzmq/master/src/src/stream_connecter_base.cpp:158
#2  0x00007ffff7b68f90 in zmq::tcp_connecter_t::out_event (this=0x7fffe80008c0) at /home/btorpey/work/libzmq/master/src/src/tcp_connecter.cpp:110
#3  0x00007ffff7b8f438 in zmq::stream_connecter_base_t::in_event (this=0x7fffe80008c0) at /home/btorpey/work/libzmq/master/src/src/stream_connecter_base.cpp:168
#4  0x00007ffff7b266a0 in zmq::epoll_t::loop (this=0x60a170) at /home/btorpey/work/libzmq/master/src/src/epoll.cpp:198
#5  0x00007ffff7b42629 in zmq::worker_poller_base_t::worker_routine (arg_=0x60a170) at /home/btorpey/work/libzmq/master/src/src/poller_base.cpp:135
#6  0x00007ffff7b6a3ba in thread_routine (arg_=0x60a1c8) at /home/btorpey/work/libzmq/master/src/src/thread.cpp:250
#7  0x00007ffff7635e65 in start_thread () from /lib64/libpthread.so.0
#8  0x00007ffff6b3f88d in clone () from /lib64/libc.so.6
```

## 2. Non-0mq process listening at port
These all rely on the 0mq handshake failing.  There are a few ways that can happen.

### 2.i Peer closes connection
In some cases, the non-0mq process will unilaterally close the connection, presumably because the greeting from 0mq process violates the non-0mq process's expected behavior.  This can either be done gracefully (Oracle listener sends a `FIN`) or forcibly (smbd sends a `RST`) -- in either case it is detected in `receive_greeting` with errno == `ECONNRESET`.

### 2.ii Peer does nothing
Some processes don't respond at all to the 0mq greeting.  In this case, the handshake times out (in `stream_engine_base_t::timer_event`)
and triggers the disconnect:

```
#0  zmq::socket_base_t::event_handshake_failed_no_detail (this=0x614590, endpoint_uri_pair_=..., err_=11)
    at /home/btorpey/work/libzmq/master/src/src/socket_base.cpp:1887
#1  0x00007ffff7b66379 in zmq::stream_engine_base_t::error (this=0x7fffe8000f80, reason_=zmq::i_engine::timeout_error)
    at /home/btorpey/work/libzmq/master/src/src/stream_engine_base.cpp:689
#2  0x00007ffff7b66818 in zmq::stream_engine_base_t::timer_event (this=0x7fffe8000f80, id_=64)
    at /home/btorpey/work/libzmq/master/src/src/stream_engine_base.cpp:737
#3  0x00007ffff7b42473 in zmq::poller_base_t::execute_timers (this=0x60a170) at /home/btorpey/work/libzmq/master/src/src/poller_base.cpp:99
#4  0x00007ffff7b2653f in zmq::epoll_t::loop (this=0x60a170) at /home/btorpey/work/libzmq/master/src/src/epoll.cpp:173
#5  0x00007ffff7b42629 in zmq::worker_poller_base_t::worker_routine (arg_=0x60a170) at /home/btorpey/work/libzmq/master/src/src/poller_base.cpp:135
#6  0x00007ffff7b6a3be in thread_routine (arg_=0x60a1c8) at /home/btorpey/work/libzmq/master/src/src/thread.cpp:250
#7  0x00007ffff7635e65 in start_thread () from /lib64/libpthread.so.0
#8  0x00007ffff6b3f88d in clone () from /lib64/libc.so.6
```

This requires the fix described [below](#Possible-bug).

### 2.iii Peer responds to greeting

Some processes do respond to the 0mq greeting. (For instance, sshd responds to the greeting with "SSH-2.0-Open", which just happens to be the same length as the unversioned 0mq greeting).

#### Specifying ZMQ_MIN_ZMTP_VERSION
One way to detect/reject non-0mq processes is to specify a minimum ZMTP version (using the `ZMQ_MIN_ZMTP_VERSION` sockopt).  Since the greeting isn't a proper ZMTP greeting, the code treats it as "unversioned", and as such it doesn't match any ZMTP version.

```
#0  zmq::socket_base_t::event_disconnected (this=0x614590, endpoint_uri_pair_=..., fd_=16) at /home/btorpey/work/libzmq/master/src/src/socket_base.cpp:1880
#1  0x00007ffff7b66394 in zmq::stream_engine_base_t::error (this=0x7fffe8000f80, reason_=zmq::i_engine::protocol_error) at /home/btorpey/work/libzmq/master/src/src/stream_engine_base.cpp:694
#2  0x00007ffff7b8ccb5 in zmq::zmtp_engine_t::handshake_v1_0_unversioned (this=0x7fffe8000f80) at /home/btorpey/work/libzmq/master/src/src/zmtp_engine.cpp:260
#3  0x00007ffff7b8c668 in zmq::zmtp_engine_t::handshake (this=0x7fffe8000f80) at /home/btorpey/work/libzmq/master/src/src/zmtp_engine.cpp:133
#4  0x00007ffff7b64492 in zmq::stream_engine_base_t::in_event_internal (this=0x7fffe8000f80) at /home/btorpey/work/libzmq/master/src/src/stream_engine_base.cpp:252
#5  0x00007ffff7b643f2 in zmq::stream_engine_base_t::in_event (this=0x7fffe8000f80) at /home/btorpey/work/libzmq/master/src/src/stream_engine_base.cpp:242
#6  0x00007ffff7b26745 in zmq::epoll_t::loop (this=0x60a170) at /home/btorpey/work/libzmq/master/src/src/epoll.cpp:206
#7  0x00007ffff7b42629 in zmq::worker_poller_base_t::worker_routine (arg_=0x60a170) at /home/btorpey/work/libzmq/master/src/src/poller_base.cpp:135
#8  0x00007ffff7b6a3ba in thread_routine (arg_=0x60a1c8) at /home/btorpey/work/libzmq/master/src/src/thread.cpp:250
#9  0x00007ffff7635e65 in start_thread () from /lib64/libpthread.so.0
#10 0x00007ffff6b3f88d in clone () from /lib64/libc.so.6
```

#### Without ZMQ_MIN_ZMTP_VERSION
Last but not least is the case where a process responds to the 0mq greeting, but for whatever reason we don't want to use `ZMQ_MIN_ZMTP_VERSION`.  This is similar to the case 2.2 above, and requires the fix mentioned [below](#Possible-bug). 

## Possible bug
In this case, it looks like there's a bug in the code -- the following sequence should move from:

```
bool zmq::zmtp_engine_t::handshake ()
{
    ...
    if (_has_handshake_timer) {
        cancel_timer (handshake_timer_id);
        _has_handshake_timer = false;
    }

    return true;
}
```

to... 

```
void zmq::stream_engine_base_t::mechanism_ready ()
{
    ...
    if (_has_handshake_timer) {
        cancel_timer (handshake_timer_id);
        _has_handshake_timer = false;
    }

    _socket->event_handshake_succeeded (_endpoint_uri_pair, 0);
}
```

Testing appears to show that handshakes will never timeout with the current version of the code.

## Other Stuff

The doc for `ZMQ_EVENT_DISCONNECTED` states:

> The socket was disconnected unexpectedly. The event value is the FD of the underlying network socket. **Warning: this socket will be closed.**

That doesn't seem to happen, and I'm curious why?

## Test Code
Code used to run these tests is at: <https://github.com/WallStProg/zmqtests/tree/master/connect>.


